### PR TITLE
Pathfinding version bump

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -18,7 +18,7 @@
         },
         {
             "id" : "Pathfinding",
-            "minVersion" : "0.2.0"
+            "minVersion" : "0.3.0-SNAPSHOT"
         },
         {
             "id" : "StructuralResources",


### PR DESCRIPTION
Set of PRs which has to be tested and merged together:

- https://github.com/MovingBlocks/Terasology/pull/3023
- https://github.com/Terasology/Pathfinding/pull/34
- https://github.com/Terasology/Behaviors/pull/7
- https://github.com/Terasology/WildAnimals/pull/22
- https://github.com/Terasology/GooeysQuests/pull/15 
- https://github.com/Terasology/LightAndShadow/pull/59
- https://github.com/Terasology/LightAndShadowResources/pull/21
- https://github.com/Terasology/StaticCities/pull/5

Short little PR to update the Pathfinding dependency, among others for Light and Shadow.