### PR TITLE
Revert "fix(StaticCities): replace perlin with simplex"

### DIFF
--- a/src/main/java/org/terasology/staticCities/CityWorldGenerator.java
+++ b/src/main/java/org/terasology/staticCities/CityWorldGenerator.java
@@ -16,7 +16,7 @@
 
 package org.terasology.staticCities;
 
-import org.terasology.core.world.generator.facetProviders.SimplexHumidityProvider;
+import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
@@ -128,7 +128,7 @@ public class CityWorldGenerator extends BaseFacetedWorldGenerator {
 
             .build();
 
-            SimplexHumidityProvider.Configuration humidityConfig = new SimplexHumidityProvider.Configuration();
+        PerlinHumidityProvider.Configuration humidityConfig = new PerlinHumidityProvider.Configuration();
         humidityConfig.octaves = 4;
         humidityConfig.scale = 0.5f;
 
@@ -141,7 +141,7 @@ public class CityWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new BuildableTerrainFacetProvider())
                 .addProvider(new BlockedAreaFacetProvider())
                 .addProvider(new LakeFacetProvider())
-                .addProvider(new SimplexHumidityProvider(humidityConfig))
+                .addProvider(new PerlinHumidityProvider(humidityConfig))
                 .addProvider(new SimpleBiomeProvider())
                 .addProvider(new SiteFacetProvider())
                 .addProvider(new TownWallFacetProvider())

--- a/src/main/java/org/terasology/staticCities/roads/RoadFacetProvider.java
+++ b/src/main/java/org/terasology/staticCities/roads/RoadFacetProvider.java
@@ -45,7 +45,7 @@ import org.terasology.staticCities.blocked.BlockedAreaFacet;
 import org.terasology.staticCities.sites.Site;
 import org.terasology.staticCities.sites.SiteFacet;
 import org.terasology.staticCities.terrain.BuildableTerrainFacet;
-import org.terasology.utilities.procedural.SimplexNoise;
+import org.terasology.utilities.procedural.PerlinNoise;
 import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.Facet;
 import org.terasology.world.generation.FacetBorder;
@@ -68,8 +68,8 @@ public class RoadFacetProvider implements FacetProvider {
 
     private final Cache<UnorderedPair<Site>, Optional<Road>> roadCache = CacheBuilder.newBuilder().build();
 
-    private SimplexNoise noiseX;
-    private SimplexNoise noiseY;
+    private PerlinNoise noiseX;
+    private PerlinNoise noiseY;
 
     /**
      * The amplitude of the noise
@@ -89,8 +89,8 @@ public class RoadFacetProvider implements FacetProvider {
 
     @Override
     public void setSeed(long seed) {
-        this.noiseX = new SimplexNoise(seed ^ 533231280);
-        this.noiseY = new SimplexNoise(seed ^ 198218712);
+        this.noiseX = new PerlinNoise(seed ^ 533231280);
+        this.noiseY = new PerlinNoise(seed ^ 198218712);
     }
 
     @Override


### PR DESCRIPTION
Reverts Terasology/StaticCities#7
Perlin and Simplex seem to differ in their noise functions. Until we know how to correctly configure Simplex to act like Perlin, this change is reverted and the removed Perlin parts reintroduced and marked as deprecated.