### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/staticCities/parcels/ParcelFacetProvider.java
+++ b/src/main/java/org/terasology/staticCities/parcels/ParcelFacetProvider.java
@@ -223,19 +223,19 @@ public class ParcelFacetProvider implements ConfigurableFacetProvider {
         }
     }
 
-    private static class ParcelConfiguration implements Component<ParcelConfiguration> {
+    public static class ParcelConfiguration implements Component<ParcelConfiguration> {
 
         @Range(min = 5f, max = 50f, increment = 1f, precision = 0, description = "The min. parcel length")
-        private float minSize = 10;
+        public float minSize = 10;
 
         @Range(min = 5f, max = 50f, increment = 1f, precision = 0, description = "The max. parcel length")
-        private float maxSize = 18;
+        public float maxSize = 18;
 
         @Range(min = 1, max = 5, increment = 1, precision = 0, description = "The max. number of placement attempts per parcel")
-        private int maxTries = 1;
+        public int maxTries = 1;
 
         @Range(min = 5, max = 250, increment = 1, precision = 0, description = "The max. number of parcels")
-        private int maxLots = 100;
+        public int maxLots = 100;
 
         @Override
         public void copyFrom(ParcelConfiguration other) {

--- a/src/main/java/org/terasology/staticCities/sites/SiteFacetProvider.java
+++ b/src/main/java/org/terasology/staticCities/sites/SiteFacetProvider.java
@@ -142,16 +142,16 @@ public class SiteFacetProvider implements ConfigurableFacetProvider {
         return true;
     }
 
-    private static class SiteConfiguration implements Component<SiteConfiguration> {
+    public static class SiteConfiguration implements Component<SiteConfiguration> {
 
         @Range(label = "Minimal town size", description = "Minimal town size in blocks", min = 1, max = 150, increment = 10, precision = 1)
-        private int minRadius = 50;
+        public int minRadius = 50;
 
         @Range(label = "Maximum town size", description = "Maximum town size in blocks", min = 10, max = 350, increment = 10, precision = 1)
-        private int maxRadius = 256;
+        public int maxRadius = 256;
 
         @Range(label = "Minimum distance between towns", min = 10, max = 1000, increment = 10, precision = 1)
-        private int minDistance = 128;
+        public int minDistance = 128;
 
         @Override
         public void copyFrom(SiteConfiguration other) {

--- a/src/main/java/org/terasology/staticCities/surface/InfiniteSurfaceHeightFacetProvider.java
+++ b/src/main/java/org/terasology/staticCities/surface/InfiniteSurfaceHeightFacetProvider.java
@@ -90,9 +90,9 @@ public class InfiniteSurfaceHeightFacetProvider implements ConfigurableFacetProv
         }
     }
 
-    private static class InfiniteSurfaceConfiguration implements Component<InfiniteSurfaceConfiguration> {
+    public static class InfiniteSurfaceConfiguration implements Component<InfiniteSurfaceConfiguration> {
         @Enum(label = "Symmetric World", description = "Check to create an axis-symmetric world")
-        private SymmetryType symmetry = SymmetryType.NONE;
+        public SymmetryType symmetry = SymmetryType.NONE;
 
         @Override
         public void copyFrom(InfiniteSurfaceConfiguration other) {


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191